### PR TITLE
Update to wgpu 23.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wgpu = "22.0.0"
+wgpu = "23.0.1"
 euclid = "0.22.7"
 fontdue = "0.8.0"
 rect_packer = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,13 +239,13 @@ impl Vger {
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "vs_main",
+                entry_point: Some("vs_main"),
                 buffers: &[],
                 compilation_options: Default::default(),
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "fs_main",
+                entry_point: Some("fs_main"),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: texture_format,
                     blend: Some(wgpu::BlendState {


### PR DESCRIPTION
This matches what is used in Vello for doing an update of both within Floem.