### PR TITLE
Fix alpha blend factor so AA edges don't leak through on transparent surfaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,21 @@ impl Vger {
             immediate_size: 0,
         });
 
-        let blend_comp = wgpu::BlendComponent {
+        // Color uses straight-alpha source-over: src.rgb * src.a + dst.rgb * (1 - src.a).
+        let color_blend = wgpu::BlendComponent {
             operation: wgpu::BlendOperation::Add,
             src_factor: wgpu::BlendFactor::SrcAlpha,
+            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+        };
+        // Alpha must use One + OneMinusSrcAlpha so the framebuffer alpha
+        // becomes `src.a + dst.a * (1 - src.a)`. The previous symmetric blend
+        // (`SrcAlpha` for both channels) squared the alpha — `src.a² + …` —
+        // so antialiased SDF / text edges with conceptual coverage `c` wrote
+        // alpha `c²` to the framebuffer, leaving the desktop visible through
+        // every glyph edge on a transparent (PreMultiplied) Wayland surface.
+        let alpha_blend = wgpu::BlendComponent {
+            operation: wgpu::BlendOperation::Add,
+            src_factor: wgpu::BlendFactor::One,
             dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
         };
 
@@ -249,8 +261,8 @@ impl Vger {
                 targets: &[Some(wgpu::ColorTargetState {
                     format: texture_format,
                     blend: Some(wgpu::BlendState {
-                        color: blend_comp,
-                        alpha: blend_comp,
+                        color: color_blend,
+                        alpha: alpha_blend,
                     }),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],


### PR DESCRIPTION
## Summary

The render pipeline uses `SrcAlpha + OneMinusSrcAlpha` for both the color
**and** alpha components of the blend state (`src/lib.rs` blend pipeline
setup). The color formula is correct source-over for a straight-alpha
fragment output:

```
out.rgb = src.rgb · src.a + dst.rgb · (1 − src.a)
```

…but applying the same factors to the alpha channel produces:

```
out.a = src.a² + dst.a · (1 − src.a)
```

— the source alpha gets **squared**. For a fragment that is conceptually
fully opaque but partially covered (AA edge of an SDF shape, antialiased
glyph), `src.a = coverage`, and the framebuffer ends up holding
`coverage²` instead of `coverage`.

On opaque surfaces (`CompositeAlphaMode::Opaque`) this is invisible — the
alpha channel is discarded. But on transparent surfaces (most Wayland
compositors negotiate `PreMultiplied`, smoked-glass overlays, layer-shell
panels, popovers) the compositor blends every glyph and rounded-corner
edge against whatever is behind the window. Result: visible desktop
shine-through at borders and text.

This PR uses the standard "source-over with straight-alpha source" alpha
formula:

```
out.a = src.a + dst.a · (1 − src.a)
```

i.e. `One + OneMinusSrcAlpha` for the alpha component. The color blend
is unchanged.

## Test plan

- [ ] Run existing vger examples on macOS / Linux X11 / Linux Wayland —
      confirm no visible regression on opaque output (alpha is discarded
      there, so should be byte-identical).
- [ ] Render the existing demos against a checkerboard backdrop on a
      transparent surface — before: alpha-squared edges visibly translucent;
      after: clean source-over compositing.

I came at this from the consumer side: the floem-based pikr launcher
(layer-shell Wayland surface) was bleeding the desktop through every
glyph edge and rounded badge corner. With this blend fix, the framebuffer
alpha matches the conceptual coverage.

## Notes

The change also adjusts `gpu_vec::bind_group_entry` to spell the
elided lifetime explicitly (`wgpu::BindGroupEntry<'_>`), silencing a
clippy `mismatched_lifetime_syntaxes` warning on recent rustc. Drop-in
clean-up only.

Branch is currently based on `cfdec48` (the rev `floem_vger_renderer`
pins); happy to rebase onto `main` if you'd like before merging.